### PR TITLE
Api de consulta dos tipos de cartões disponíveis

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,0 +1,15 @@
+class Api::V1::ApiController < ActionController::API
+	rescue_from ActiveRecord::ActiveRecordError, with: :return_500
+	rescue_from ActiveRecord::RecordNotFound, with: :return_404
+
+	
+	private
+	
+	def return_500
+		render status: 500, json: { errors: 'Erro interno da Aplicação' }
+	end
+	
+	def return_404
+		render status: 404, json: { errors: 'Erro de entidade não encontrada' }
+	end
+end

--- a/app/controllers/api/v1/company_card_types_controller.rb
+++ b/app/controllers/api/v1/company_card_types_controller.rb
@@ -1,0 +1,10 @@
+class Api::V1::CompanyCardTypesController < Api::V1::ApiController
+
+  def index
+    company = CompanyCardType.where(cnpj: params[:cnpj])
+    card_types = company.where(status: 5)
+    card_types = card_types.map {|c| { id: c.card_type.id, name: c.card_type.name, icon: c.card_type.icon,
+                                start_points: c.card_type.start_points, conversion_tax: c.conversion_tax.to_f } }
+    render status: 200, json: card_types
+  end
+end

--- a/app/models/card_type.rb
+++ b/app/models/card_type.rb
@@ -1,2 +1,4 @@
 class CardType < ApplicationRecord
+
+  has_many :company_card_types
 end

--- a/app/models/company_card_type.rb
+++ b/app/models/company_card_type.rb
@@ -1,3 +1,4 @@
 class CompanyCardType < ApplicationRecord
   belongs_to :card_type
+  enum status: { pending: 0, active: 5}
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,11 @@
 Rails.application.routes.draw do
   devise_for :admins
   root "home#index"
+
+  namespace :api do
+    namespace :v1 do
+      resources :company_card_types, only: [:index]
+      # get 'company_card_types/:cnpj' to: 'company_card_types#index'
+    end
+  end
 end

--- a/spec/requests/APIs/get_card_types_API_spec.rb
+++ b/spec/requests/APIs/get_card_types_API_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe 'API do tipo de cartão' do
+  context 'GET /api/v1/company_card_types/02423374000145' do 
+    it 'success' do
+      card_type = CardType.create!(name: 'Black', icon: 'icone', start_points: 210)
+      company_card_type = CompanyCardType.create!(status: :active, cnpj: '02423374000145', 
+                                                  card_type: card_type, conversion_tax: 20.00)
+
+      get "/api/v1/company_card_types/#{company_card_type.cnpj}"
+
+      expect(response.status).to eq 200
+      expect(response.content_type).to include 'application/json'
+      json_response = JSON.parse(response.body)
+      expect(json_response.length).to eq 1
+      expect(json_response[0]['name']).to eq 'Black'
+      expect(json_response[0]['icon']).to eq 'icone'
+      expect(json_response[0]['id']).to eq 1
+      expect(json_response[0]['start_points']).to eq 210
+      expect(json_response[0]['conversion_tax']).to eq 20.00
+    end
+  end
+end

--- a/spec/requests/APIs/get_card_types_API_spec.rb
+++ b/spec/requests/APIs/get_card_types_API_spec.rb
@@ -1,23 +1,60 @@
 require 'rails_helper'
 
 describe 'API do tipo de cartão' do
-  context 'GET /api/v1/company_card_types/02423374000145' do 
-    it 'success' do
+  context 'GET /api/v1/company_card_types?cnpj=cnpj_number' do
+    it 'retorna vazio se não tiver tipo de cartão disponível' do
+      # Arrange
+      
+      # Act
+      get "/api/v1/company_card_types?cnpj=000000000000000"
+      
+      # Assert
+      expect(response.status).to eq 200
+      expect(response.content_type).to include 'application/json'
+      json_response = JSON.parse(response.body)
+      expect(json_response).to eq []
+    end
+
+    it 'retorna erro em caso de falha interna' do
+      # Arrange
+      allow(CompanyCardType).to receive(:where).and_raise(ActiveRecord::ActiveRecordError)
+      
+      # Act
+      get "/api/v1/company_card_types?cnpj=000000000000000"
+      
+      # Assert
+      expect(response.status).to eq 500
+    end
+    
+    it 'com sucesso' do
       card_type = CardType.create!(name: 'Black', icon: 'icone', start_points: 210)
+      other_card_type = CardType.create!(name: 'Premium', icon: 'icone', start_points: 170)
+      card_type_2 = CardType.create!(name: 'Starter', icon: 'icone2', start_points: 150)
       company_card_type = CompanyCardType.create!(status: :active, cnpj: '02423374000145', 
                                                   card_type: card_type, conversion_tax: 20.00)
+      CompanyCardType.create!(status: :pending, cnpj: '02423374000145', 
+                              card_type: other_card_type, conversion_tax: 10.00)
+      CompanyCardType.create!(status: :active, cnpj: '12423374000146', 
+                                card_type: card_type, conversion_tax: 15.00)
+      CompanyCardType.create!(status: :active, cnpj: '02423374000145', 
+                                  card_type: card_type_2, conversion_tax: 12.00)                                           
 
-      get "/api/v1/company_card_types/#{company_card_type.cnpj}"
+      get "/api/v1/company_card_types?cnpj=#{company_card_type.cnpj}"
 
       expect(response.status).to eq 200
       expect(response.content_type).to include 'application/json'
       json_response = JSON.parse(response.body)
-      expect(json_response.length).to eq 1
+      expect(json_response.length).to eq 2
       expect(json_response[0]['name']).to eq 'Black'
       expect(json_response[0]['icon']).to eq 'icone'
       expect(json_response[0]['id']).to eq 1
       expect(json_response[0]['start_points']).to eq 210
       expect(json_response[0]['conversion_tax']).to eq 20.00
+      expect(json_response[1]['name']).to eq 'Starter'
+      expect(json_response[1]['icon']).to eq 'icone2'
+      expect(json_response[1]['id']).to eq 3
+      expect(json_response[1]['start_points']).to eq 150
+      expect(json_response[1]['conversion_tax']).to eq 12.00
     end
   end
 end


### PR DESCRIPTION
Foi disponibilizado um endpoint na API para consulta através do cnpj dos tipos de cartões disponíveis para aquela empresa, além de um controller para gerenciar os retornos de erro.

close #6 