### PR TITLE
Habilitar e desabilitar a emissão de tipos de cartão

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-# README
+# Gestão de Cartões e Pagamentos
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## Sumário
+* [Funcionalidades](#funcionalidades)
+* [Configurações](#configurações)
 
-Things you may want to cover:
+## Funcionalidades
+### Controle de Usuários
+### Gestão de Tipos de Cartão
+### Emissão de cartões
+### Controle de pontos
+### Pagamentos
+### Cashback
 
-* Ruby version
 
-* System dependencies
+## Configurações
+### Como Rodar a Aplicação
 
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+* Para os ícones do tipo de cartão use as urls aboixo como exemplo
+    ```
+     https://raw.githubusercontent.com/GA9BR1/card_type_images/main/black.svg
+     https://raw.githubusercontent.com/GA9BR1/card_type_images/main/gold.svg
+     https://raw.githubusercontent.com/GA9BR1/card_type_images/main/platinum.svg   
+    ```

--- a/app/assets/stylesheets/card_types/style.scss
+++ b/app/assets/stylesheets/card_types/style.scss
@@ -1,11 +1,16 @@
-#errors-div {
+.errors-div {
     display: flex;
     flex-direction: column;
     text-align: center;
 }
 
-#card-type-form {
+.card-type-form {
     display: flex;
     flex-direction: column;
     align-items: center;
+}
+
+.card-footer{
+    display: flex;
+    gap: 1em;
 }

--- a/app/controllers/card_types_controller.rb
+++ b/app/controllers/card_types_controller.rb
@@ -1,6 +1,8 @@
 class CardTypesController < ApplicationController
   def index
     @card_types = CardType.all
+    @cards_emission_enabled = CardType.enabled
+    @cards_emission_disabled = CardType.disabled
   end
 
   def show
@@ -32,6 +34,23 @@ class CardTypesController < ApplicationController
     flash.now[:alert] = 'Não foi possível salvar as alterações'
     render :edit, status: :unprocessable_entity
   end
+
+  def disable
+    @card_type = CardType.find(params[:id])
+    @card_type.emission = false
+    @card_type.save!
+    
+    return redirect_to @card_type, notice: 'Emissão do cartão desabilitada com sucesso'
+  end
+
+  def enable
+    @card_type = CardType.find(params[:id])
+    @card_type.emission = true
+    @card_type.save!
+    
+    return redirect_to @card_type, notice: 'Emissão do cartão habilitada com sucesso'
+  end
+
 
   private
 

--- a/app/controllers/card_types_controller.rb
+++ b/app/controllers/card_types_controller.rb
@@ -37,18 +37,17 @@ class CardTypesController < ApplicationController
     @card_type = CardType.find(params[:id])
     @card_type.emission = false
     @card_type.save!
-    
-    return redirect_to @card_type, notice: 'Emissão do cartão desabilitada com sucesso'
+
+    redirect_to @card_type, notice: I18n.t('notices.card_type_disabled')
   end
 
   def enable
     @card_type = CardType.find(params[:id])
     @card_type.emission = true
     @card_type.save!
-    
-    return redirect_to @card_type, notice: 'Emissão do cartão habilitada com sucesso'
-  end
 
+    redirect_to @card_type, notice: I18n.t('notices.card_type_enabled')
+  end
 
   private
 

--- a/app/models/card_type.rb
+++ b/app/models/card_type.rb
@@ -2,11 +2,6 @@ class CardType < ApplicationRecord
   validates :name, :icon, :start_points, presence: true
   validates :name, :icon, uniqueness: true
 
-  def self.enabled
-    CardType.where(emission: true)
-  end
-
-  def self.disabled
-    CardType.where(emission: false)
-  end
+  scope :enabled, -> { where(emission: true) }
+  scope :disabled, -> { where(emission: false) }
 end

--- a/app/models/card_type.rb
+++ b/app/models/card_type.rb
@@ -1,4 +1,13 @@
 class CardType < ApplicationRecord
   validates :name, :icon, :start_points, presence: true
   validates :name, :icon, uniqueness: true
+
+  def self.enabled
+    CardType.where(emission: true)
+  end
+
+  def self.disabled
+    CardType.where(emission: false)
+  end
+
 end

--- a/app/models/card_type.rb
+++ b/app/models/card_type.rb
@@ -9,5 +9,4 @@ class CardType < ApplicationRecord
   def self.disabled
     CardType.where(emission: false)
   end
-
 end

--- a/app/views/card_types/edit.html.erb
+++ b/app/views/card_types/edit.html.erb
@@ -2,7 +2,7 @@
   <h1>Editar tipo de cartão</h1>
   <% if @card_type.errors.present? %>
       <h4>Verifique os erros abaixo:</h4>
-      <div id='errors-div'>
+      <div class='errors-div'>
       <% @card_type.errors.full_messages.each do |message| %>
           <span><%= message %></span>
       <% end %>

--- a/app/views/card_types/index.html.erb
+++ b/app/views/card_types/index.html.erb
@@ -1,9 +1,29 @@
-<section>
-    <%if @card_types.empty?%>
-        <span>Nenhum tipo de cartão criado</span>
-    <%else%>
-        <%@card_types.each do |type|%>
-            <%= link_to type.name, type%>
-        <%end%>
-    <%end%>
+<section class='d-md-flex p-2'>
+    <div id='emission-enabled-card-types' class='container'>
+        <h4>Tipos habilitados para emissão:</h4>
+        <% if @cards_emission_enabled.empty? %>
+            <span>Nenhum tipo de cartão com emissão habilitada</span>
+        <% else %>
+            <%@cards_emission_enabled.each do |type|%>
+                <div class='row align-items-center my-2'>
+                    <%= link_to type.name, type, :class => 'col'%>
+                    <%= image_tag type.icon, alt: "Ícone cartão #{type.name}", :class => 'col', width: 25, height: 25%>
+                </div>
+             <%end%>
+         <% end %>
+  </div>
+
+  <div id='emission-disabled-card-types' class='container'>
+        <h4>Tipos desabilitados para emissão:</h4>
+        <% if @cards_emission_disabled.empty? %>
+            <span>Nenhum tipo de cartão com emissão desabilitada</span>
+        <% else %>
+            <%@cards_emission_disabled.each do |type|%>
+                <div class='row align-items-center'>
+                    <%= link_to type.name, type , :class => 'col'%>
+                    <%= image_tag type.icon, alt: "Ícone cartão #{type.name}", :class => 'col', width: 25, height: 25%>
+                </div>
+            <%end%>
+        <% end %>
+    </div>
 </section>

--- a/app/views/card_types/new.html.erb
+++ b/app/views/card_types/new.html.erb
@@ -1,4 +1,4 @@
-<section id='card-type-form'>
+<section class='card-type-form'>
   <h1>Novo tipo de cartão</h1>
   <% if @card_type.errors.present? %>
     <h4>Verifique os erros abaixo:</h4>

--- a/app/views/card_types/show.html.erb
+++ b/app/views/card_types/show.html.erb
@@ -1,10 +1,15 @@
 <section class='card w-25 mx-auto'>
   <h1 class='card-header'>Cartão <%= @card_type.name %></h1>
-  <%= image_tag @card_type.icon, alt: "Ícone cartão #{@card_type.name}", :class => 'card-img-top px-5'%>
+  <%= image_tag @card_type.icon, alt: "Ícone cartão #{@card_type.name}", :class => 'card-img-top p-3'%>
   <div class='card-body'>
     <span class='card-text'>Pontos iniciais: <%= @card_type.start_points %></span>
   </div>
   <div class='card-footer'>
     <%=link_to 'Editar', edit_card_type_path(@card_type), :class => 'btn btn-secondary'%>
+    <% if @card_type.emission %>
+      <%= button_to 'Desabilitar emissão', disable_card_type_path(@card_type), :class => 'btn btn-danger', method: :patch %>
+    <% else %>
+      <%= button_to 'Habilitar emissão', enable_card_type_path(@card_type), :class => 'btn btn-success', method: :patch %>
+    <% end %>
   </div>
 </section>

--- a/config/locales/notices.pt-br.yml
+++ b/config/locales/notices.pt-br.yml
@@ -1,3 +1,5 @@
 pt-BR:
   notices:
     card_type_created: Novo tipo de cartão criado com sucesso
+    card_type_disabled: Emissão do cartão desabilitada com sucesso
+    card_type_enabled: Emissão do cartão habilitada com sucesso

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
   devise_for :admins
   root "home#index"
-  resources :card_types, only: [:index, :new, :create, :show, :edit, :update]
+  resources :card_types, only: [:index, :new, :create, :show, :edit, :update] do
+    patch 'enable', on: :member
+    patch 'disable', on: :member
+  end
 end

--- a/spec/system/card_types/user_change_card_type_status_spec.rb
+++ b/spec/system/card_types/user_change_card_type_status_spec.rb
@@ -11,11 +11,9 @@ describe 'Usuário tenta mudar status do cartão' do
 
     expect(page).to have_button 'Desabilitar emissão'
     expect(page).not_to have_button 'Hablitar emissão'
-
   end
 
   it 'e desabilita com sucesso' do
-
     FactoryBot.create(:card_type, emission: true, name: 'Platinum')
 
     visit root_path
@@ -25,6 +23,5 @@ describe 'Usuário tenta mudar status do cartão' do
 
     expect(page).to have_button 'Habilitar emissão'
     expect(page).not_to have_button 'Desabilitar emissão'
-
   end
 end

--- a/spec/system/card_types/user_change_card_type_status_spec.rb
+++ b/spec/system/card_types/user_change_card_type_status_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe 'Usuário tenta mudar status do cartão' do
+  it 'e habilita com sucesso' do
+    FactoryBot.create(:card_type, emission: false, name: 'Platinum')
+
+    visit root_path
+    click_on 'Tipos de cartão'
+    click_on 'Platinum'
+    click_on 'Habilitar emissão'
+
+    expect(page).to have_button 'Desabilitar emissão'
+    expect(page).not_to have_button 'Hablitar emissão'
+
+  end
+
+  it 'e desabilita com sucesso' do
+
+    FactoryBot.create(:card_type, emission: true, name: 'Platinum')
+
+    visit root_path
+    click_on 'Tipos de cartão'
+    click_on 'Platinum'
+    click_on 'Desabilitar emissão'
+
+    expect(page).to have_button 'Habilitar emissão'
+    expect(page).not_to have_button 'Desabilitar emissão'
+
+  end
+end

--- a/spec/system/card_types/user_view_card_types_spec.rb
+++ b/spec/system/card_types/user_view_card_types_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe 'Usuário tenta ver os tipos de cartão' do
+  it 'com sucesso' do
+    FactoryBot.create(:card_type, name: 'Black', start_points: 1500, emission: true, icon: 'https://raw.githubusercontent.com/GA9BR1/card_type_images/main/black.svg')
+    FactoryBot.create(:card_type, name: 'Platinum', start_points: 800, emission: false, icon: 'https://raw.githubusercontent.com/GA9BR1/card_type_images/main/platinum.svg')
+
+    visit root_path
+    click_on 'Tipos de cartão'
+    
+    within 'div#emission-enabled-card-types' do
+      expect(page).to have_content('Black')
+      expect(page).to have_css("img[src*='black.svg']")
+    end
+    within 'div#emission-disabled-card-types' do
+      expect(page).to have_content('Platinum')
+      expect(page).to have_css("img[src*='platinum.svg']")
+    end
+  end
+end

--- a/spec/system/card_types/user_view_card_types_spec.rb
+++ b/spec/system/card_types/user_view_card_types_spec.rb
@@ -17,4 +17,16 @@ describe 'Usuário tenta ver os tipos de cartão' do
       expect(page).to have_css("img[src*='platinum.svg']")
     end
   end
+
+  it 'e não existe nenhum tipo cadastrado' do
+    visit root_path
+    click_on 'Tipos de cartão'
+
+    within 'div#emission-enabled-card-types' do
+      expect(page).to have_content('Nenhum tipo de cartão com emissão habilitada')
+    end
+    within 'div#emission-disabled-card-types' do
+      expect(page).to have_content('Nenhum tipo de cartão com emissão desabilitada')
+    end
+  end
 end

--- a/spec/system/card_types/user_view_card_types_spec.rb
+++ b/spec/system/card_types/user_view_card_types_spec.rb
@@ -7,7 +7,7 @@ describe 'Usuário tenta ver os tipos de cartão' do
 
     visit root_path
     click_on 'Tipos de cartão'
-    
+
     within 'div#emission-enabled-card-types' do
       expect(page).to have_content('Black')
       expect(page).to have_css("img[src*='black.svg']")


### PR DESCRIPTION
Close #4 
Essa pull request adiciona
- A capacidade de desativar  ou ativar a emissão de um tipo de cartão.
- Também foram realizadas estilizações no index dos tipos de cartão.
- O Readme também foi atualizado