### PR TITLE
API de bloqueio definitivo de cartão

### DIFF
--- a/app/controllers/api/v1/cards_controller.rb
+++ b/app/controllers/api/v1/cards_controller.rb
@@ -10,9 +10,15 @@ class Api::V1::CardsController < Api::V1::ApiController
     end
   end
 
-  def destroy
+  def update
     card = Card.find(params[:id])
     card.update!(status: :inactive)
+    render status: :ok, json: format_created_card(card)
+  end
+
+  def destroy
+    card = Card.find(params[:id])
+    card.update!(status: :blocked)
     render status: :ok, json: format_created_card(card)
   end
 

--- a/app/controllers/api/v1/cards_controller.rb
+++ b/app/controllers/api/v1/cards_controller.rb
@@ -12,14 +12,20 @@ class Api::V1::CardsController < Api::V1::ApiController
 
   def update
     card = Card.find(params[:id])
-    card.update!(status: :inactive)
-    render status: :ok, json: format_created_card(card)
+    if card.update(status: :inactive)
+      render status: :ok, json: format_created_card(card)
+    else
+      render status: :precondition_failed, json: { errors: card.errors.full_messages }
+    end
   end
 
-  def destroy
+  def block
     card = Card.find(params[:id])
-    card.update!(status: :blocked)
-    render status: :ok, json: format_created_card(card)
+    if card.update(status: :blocked)
+      render status: :ok, json: format_created_card(card)
+    else
+      render status: :precondition_failed, json: { errors: card.errors.full_messages }
+    end
   end
 
   private

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -5,6 +5,7 @@ class Card < ApplicationRecord
   validates :cpf, :number, :points, presence: true
   validate :unique_cpf_active_card, on: :create
   validate :valid_available_card_type, on: :create
+  validate :check_block, on: :update
 
   before_validation :generate_number, on: :create
   before_validation :set_initial_points, on: :create
@@ -22,6 +23,11 @@ class Card < ApplicationRecord
     cards = Card.where(cpf:)
     active_card = cards.where(status: :active)
     errors.add(:cpf, 'já possui um cartão ativo') unless active_card.empty?
+  end
+
+  def check_block
+    card = Card.find(id)
+    errors.add(:status, 'bloqueado não permite alterações no cartão') if card.status == 'blocked'
   end
 
   def generate_number

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,6 +1,6 @@
 class Card < ApplicationRecord
   belongs_to :company_card_type
-  enum status: { active: 0, inactive: 5 }
+  enum status: { active: 0, inactive: 5, blocked: 10 }
   attribute :status, default: :active
   validates :cpf, :number, :points, presence: true
   validate :unique_cpf_active_card, on: :create

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :company_card_types, only: [:index]
-      resources :cards, only: [:create, :destroy]
+      resources :cards, only: [:create, :update, :destroy]
     end
   end
   resources :card_types, only: [:index, :new, :create, :show, :edit, :update] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :company_card_types, only: [:index]
-      resources :cards, only: [:create, :update, :destroy]
+      resources :cards, only: [:create, :update] do
+        delete 'block', on: :member
+      end
     end
   end
   resources :card_types, only: [:index, :new, :create, :show, :edit, :update] do

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -99,4 +99,16 @@ RSpec.describe Card, type: :model do
       expect(result).to eq 'active'
     end
   end
+
+  describe 'com status bloqueado' do
+    it 'não permite atualização' do
+      company_card_type = FactoryBot.create(:company_card_type)
+      card = Card.create!(cpf: '78956470081', status: :blocked, company_card_type:)
+
+      result = card.update(status: :active)
+
+      expect(result).to eq false
+      expect(card.errors.full_messages).to include 'Status bloqueado não permite alterações no cartão'
+    end
+  end
 end

--- a/spec/requests/APIs/block_card_api_spec.rb
+++ b/spec/requests/APIs/block_card_api_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-describe 'API para desativação de cartão' do
-  context 'PATCH /api/v1/cards/:id' do
-    it 'falha se não existir o cartão que será desativado' do
-      patch '/api/v1/cards/1'
+describe 'API para bloqueio definitivo de cartão' do
+  context 'DELETE /api/v1/cards/:id' do
+    it 'falha se não existir o cartão que será bloqueado' do
+      delete '/api/v1/cards/1'
 
       expect(response.status).to eq 404
     end
@@ -14,7 +14,7 @@ describe 'API para desativação de cartão' do
 
       card = Card.create!(cpf: '12193448000158', company_card_type_id: 1)
 
-      patch "/api/v1/cards/#{card.id}"
+      delete "/api/v1/cards/#{card.id}"
 
       expect(response.status).to eq 500
     end
@@ -23,16 +23,16 @@ describe 'API para desativação de cartão' do
       allow(SecureRandom).to receive(:random_number).and_return('12345678912345678912')
       FactoryBot.create(:company_card_type)
 
-      card = Card.create!(cpf: '12193448000158', company_card_type_id: 1)
+      Card.create!(cpf: '12193448000158', company_card_type_id: 1)
 
-      patch "/api/v1/cards/#{card.id}"
+      delete '/api/v1/cards/1'
 
       expect(response.status).to eq 200
       expect(response.content_type).to include 'application/json'
       json_response = response.parsed_body
       expect(json_response['number']).to eq '12345678912345678912'
       expect(json_response['cpf']).to eq '12193448000158'
-      expect(json_response['status']).to eq 'inactive'
+      expect(json_response['status']).to eq 'blocked'
       expect(json_response['points']).to eq 100
       expect(json_response['name']).to eq 'Premium'
     end

--- a/spec/requests/APIs/block_card_api_spec.rb
+++ b/spec/requests/APIs/block_card_api_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe 'API para bloqueio definitivo de cartão' do
-  context 'DELETE /api/v1/cards/:id' do
+  context 'DELETE /api/v1/cards/:id/block' do
     it 'falha se não existir o cartão que será bloqueado' do
-      delete '/api/v1/cards/1'
+      delete '/api/v1/cards/1/block'
 
       expect(response.status).to eq 404
     end
@@ -14,9 +14,20 @@ describe 'API para bloqueio definitivo de cartão' do
 
       card = Card.create!(cpf: '12193448000158', company_card_type_id: 1)
 
-      delete "/api/v1/cards/#{card.id}"
+      delete "/api/v1/cards/#{card.id}/block"
 
       expect(response.status).to eq 500
+    end
+
+    it 'retorna erro em caso de cartão já bloqueado' do
+      FactoryBot.create(:company_card_type)
+
+      card = Card.create!(cpf: '12193448000158', company_card_type_id: 1, status: :blocked)
+
+      delete "/api/v1/cards/#{card.id}/block"
+
+      expect(response.status).to eq 412
+      expect(response.body).to include 'Status bloqueado não permite alterações no cartão'
     end
 
     it 'com sucesso' do
@@ -25,7 +36,7 @@ describe 'API para bloqueio definitivo de cartão' do
 
       Card.create!(cpf: '12193448000158', company_card_type_id: 1)
 
-      delete '/api/v1/cards/1'
+      delete '/api/v1/cards/1/block'
 
       expect(response.status).to eq 200
       expect(response.content_type).to include 'application/json'

--- a/spec/requests/APIs/deactivate_card_api_spec.rb
+++ b/spec/requests/APIs/deactivate_card_api_spec.rb
@@ -19,6 +19,17 @@ describe 'API para desativação de cartão' do
       expect(response.status).to eq 500
     end
 
+    it 'retorna erro em caso de cartão já bloqueado' do
+      FactoryBot.create(:company_card_type)
+
+      card = Card.create!(cpf: '12193448000158', company_card_type_id: 1, status: :blocked)
+
+      patch "/api/v1/cards/#{card.id}"
+
+      expect(response.status).to eq 412
+      expect(response.body).to include 'Status bloqueado não permite alterações no cartão'
+    end
+
     it 'com sucesso' do
       allow(SecureRandom).to receive(:random_number).and_return('12345678912345678912')
       FactoryBot.create(:company_card_type)


### PR DESCRIPTION
Criação do endpoint para bloqueio definitivo de um cartão.

Receberá o id do cartão através da rota e mudará o status para 'blocked'.

close #22 