### PR TITLE
Feito API para consulta de pagamentos

### DIFF
--- a/app/controllers/api/v1/payments_controller.rb
+++ b/app/controllers/api/v1/payments_controller.rb
@@ -1,4 +1,10 @@
 class Api::V1::PaymentsController < Api::V1::ApiController
+  def index
+    payment = Payment.find_by!(code: params[:code])
+    json_payment = format_created_payment(payment)
+    render status: :ok, json: json_payment
+  end
+
   def create
     payment_params = params.require(:payment).permit(:order_number, :total_value, :descount_amount, :final_value,
                                                      :cpf, :card_number, :payment_date)
@@ -9,13 +15,6 @@ class Api::V1::PaymentsController < Api::V1::ApiController
     else
       render status: :precondition_failed, json: { errors: payment.errors.full_messages }
     end
-  end
-  
-  def index
-    payment = Payment.find_by!(code: params[:code])
-
-    json_payment = format_created_payment(payment)
-    render status: :ok, json: json_payment
   end
 
   private

--- a/app/controllers/api/v1/payments_controller.rb
+++ b/app/controllers/api/v1/payments_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::PaymentsController < Api::V1::ApiController
+  def index
+    payment = Payment.find_by!(code: params[:code])
+
+    json_payment = format_created_payment(payment)
+    render status: :ok, json: json_payment
+  end
+
+  private
+
+  def format_created_payment(payment)
+    { order_number: payment.order_number,
+      total_value: payment.total_value,
+      descount_amount: payment.descount_amount,
+      final_value: payment.final_value,
+      cpf: payment.cpf,
+      card_number: payment.card_number,
+      status: payment.status,
+      code: payment.code }
+  end
+end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,2 +1,3 @@
 class Payment < ApplicationRecord
+  enum status: { pending: 0, approved: 3, rejected: 5 }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :company_card_types, only: [:index]
+      resources :payments, only: [:index]
       resources :cards, only: [:create, :update] do
         delete 'block', on: :member
       end

--- a/spec/requests/APIs/get_payment_api_spec.rb
+++ b/spec/requests/APIs/get_payment_api_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+describe 'API de consulta do pagamento' do
+  context 'GET /api/v1/payments?code=code_number' do
+    it 'com sucesso' do
+      payment = Payment.create!(order_number: '852369',
+                                code: 'EKMZVUVIWU',
+                                total_value: 500,
+                                descount_amount: 50,
+                                final_value: 450,
+                                status: 'pending',
+                                cpf: '15756448506',
+                                card_number: '98765432165432198765')
+
+      get "/api/v1/payments?code=#{payment.code}"
+
+      expect(response.status).to eq 200
+      expect(response.content_type).to include 'application/json'
+      json_response = response.parsed_body
+      expect(json_response['order_number']).to eq '852369'
+      expect(json_response['total_value']).to eq 500
+      expect(json_response['descount_amount']).to eq 50
+      expect(json_response['final_value']).to eq 450
+      expect(json_response['cpf']).to eq '15756448506'
+      expect(json_response['card_number']).to eq '98765432165432198765'
+      expect(json_response['code']).to eq 'EKMZVUVIWU'
+      expect(json_response['status']).to eq 'pending'
+    end
+
+    it 'retorna apenas o pagamento do codigo informado' do
+      payment = Payment.create!(order_number: '852369',
+                                code: 'EKMZVUVIWU',
+                                total_value: 500,
+                                descount_amount: 50,
+                                final_value: 450,
+                                status: 'pending',
+                                cpf: '15756448506',
+                                card_number: '98765432165432198765')
+
+      Payment.create!(order_number: '456123',
+                      code: 'T37PD3ARY0',
+                      total_value: 300,
+                      descount_amount: 50,
+                      final_value: 250,
+                      status: 'pending',
+                      cpf: '04621165062',
+                      card_number: '87452147852365874125')
+
+      get "/api/v1/payments?code=#{payment.code}"
+
+      expect(response.status).to eq 200
+      expect(response.content_type).to include 'application/json'
+      json_response = response.parsed_body
+      expect(json_response['order_number']).to eq '852369'
+      expect(json_response['total_value']).to eq 500
+      expect(json_response['descount_amount']).to eq 50
+      expect(json_response['final_value']).to eq 450
+      expect(json_response['cpf']).to eq '15756448506'
+      expect(json_response['card_number']).to eq '98765432165432198765'
+      expect(json_response['code']).to eq 'EKMZVUVIWU'
+      expect(json_response['status']).to eq 'pending'
+    end
+
+    it 'retonar erro caso não encontre um código informado' do
+      Payment.create!(order_number: '852369',
+                      code: 'EKMZVUVIWU',
+                      total_value: 500,
+                      descount_amount: 50,
+                      final_value: 450,
+                      status: 'pending',
+                      cpf: '15756448506',
+                      card_number: '98765432165432198765')
+      code = 'DW4NWMSBWJ'
+
+      get "/api/v1/payments?code=#{code}"
+
+      expect(response.status).to eq 404
+      expect(response.content_type).to include 'application/json'
+    end
+
+    it 'retorna erro em caso de falha interna' do
+      allow(Payment).to receive(:find_by!).and_raise(ActiveRecord::ActiveRecordError)
+
+      payment = Payment.create!(order_number: '852369',
+                                code: 'EKMZVUVIWU',
+                                total_value: 500,
+                                descount_amount: 50,
+                                final_value: 450,
+                                status: 'pending',
+                                cpf: '15756448506',
+                                card_number: '98765432165432198765')
+
+      get "/api/v1/payments?#{payment.code}"
+
+      expect(response.status).to eq 500
+    end
+  end
+end

--- a/spec/requests/APIs/get_payment_api_spec.rb
+++ b/spec/requests/APIs/get_payment_api_spec.rb
@@ -4,13 +4,13 @@ describe 'API de consulta do pagamento' do
   context 'GET /api/v1/payments?code=code_number' do
     it 'com sucesso' do
       payment = Payment.create!(order_number: '852369',
-                                code: 'EKMZVUVIWU',
                                 total_value: 500,
                                 descount_amount: 50,
                                 final_value: 450,
                                 status: 'pending',
                                 cpf: '15756448506',
-                                card_number: '98765432165432198765')
+                                card_number: '98765432165432198765',
+                                payment_date: Date.current)
 
       get "/api/v1/payments?code=#{payment.code}"
 
@@ -23,28 +23,28 @@ describe 'API de consulta do pagamento' do
       expect(json_response['final_value']).to eq 450
       expect(json_response['cpf']).to eq '15756448506'
       expect(json_response['card_number']).to eq '98765432165432198765'
-      expect(json_response['code']).to eq 'EKMZVUVIWU'
+      expect(json_response['code']).to eq payment.code
       expect(json_response['status']).to eq 'pending'
     end
 
     it 'retorna apenas o pagamento do codigo informado' do
       payment = Payment.create!(order_number: '852369',
-                                code: 'EKMZVUVIWU',
                                 total_value: 500,
                                 descount_amount: 50,
                                 final_value: 450,
                                 status: 'pending',
                                 cpf: '15756448506',
-                                card_number: '98765432165432198765')
+                                card_number: '98765432165432198765',
+                                payment_date: Date.current)
 
       Payment.create!(order_number: '456123',
-                      code: 'T37PD3ARY0',
                       total_value: 300,
                       descount_amount: 50,
                       final_value: 250,
                       status: 'pending',
                       cpf: '04621165062',
-                      card_number: '87452147852365874125')
+                      card_number: '87452147852365874125',
+                      payment_date: Date.current)
 
       get "/api/v1/payments?code=#{payment.code}"
 
@@ -57,19 +57,19 @@ describe 'API de consulta do pagamento' do
       expect(json_response['final_value']).to eq 450
       expect(json_response['cpf']).to eq '15756448506'
       expect(json_response['card_number']).to eq '98765432165432198765'
-      expect(json_response['code']).to eq 'EKMZVUVIWU'
+      expect(json_response['code']).to eq payment.code
       expect(json_response['status']).to eq 'pending'
     end
 
     it 'retonar erro caso não encontre um código informado' do
       Payment.create!(order_number: '852369',
-                      code: 'EKMZVUVIWU',
                       total_value: 500,
                       descount_amount: 50,
                       final_value: 450,
                       status: 'pending',
                       cpf: '15756448506',
-                      card_number: '98765432165432198765')
+                      card_number: '98765432165432198765',
+                      payment_date: Date.current)
       code = 'DW4NWMSBWJ'
 
       get "/api/v1/payments?code=#{code}"
@@ -82,13 +82,13 @@ describe 'API de consulta do pagamento' do
       allow(Payment).to receive(:find_by!).and_raise(ActiveRecord::ActiveRecordError)
 
       payment = Payment.create!(order_number: '852369',
-                                code: 'EKMZVUVIWU',
                                 total_value: 500,
                                 descount_amount: 50,
                                 final_value: 450,
                                 status: 'pending',
                                 cpf: '15756448506',
-                                card_number: '98765432165432198765')
+                                card_number: '98765432165432198765',
+                                payment_date: Date.current)
 
       get "/api/v1/payments?#{payment.code}"
 


### PR DESCRIPTION
Criação da endpoint para consulta do pedido através do código de pagamento.

A endpoint retorna:
- Número do pedido
- CPF
- Valor total
- Valor do desconto
- Valor final
- Status
- Código do pedido
- Número do cartão
- Data de pagamento

Rota para endpoint "/api/v1/payments?code=#{código-do-pagamento}"

close #18 