### PR TITLE
Correção das seeds e adicionado retorno da taxa na API de cartão 

### DIFF
--- a/app/controllers/api/v1/cards_controller.rb
+++ b/app/controllers/api/v1/cards_controller.rb
@@ -85,7 +85,8 @@ class Api::V1::CardsController < Api::V1::ApiController
       number: card.number,
       points: card.points,
       status: card.status,
-      name: card.company_card_type.card_type.name
+      name: card.company_card_type.card_type.name,
+      conversion_tax: card.company_card_type.conversion_tax
     }
   end
 end

--- a/app/controllers/api/v1/company_card_types_controller.rb
+++ b/app/controllers/api/v1/company_card_types_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::CompanyCardTypesController < Api::V1::ApiController
   def format_card_type_body(card_types)
     card_types.map do |c|
       {
-        id: c.id,
+        company_card_type_id: c.id,
         name: c.card_type.name,
         icon: c.card_type.icon,
         start_points: c.card_type.start_points,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,7 +42,7 @@ payment = Payment.create!(
   cpf: card.cpf,
   status: :pending,
   card_number: card.number,
-  payment_date: Date.today
+  payment_date: Date.current
 )
 Extract.create!(
   date: payment.created_at, operation_type: 'débito', value: payment.final_value,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -40,8 +40,9 @@ payment = Payment.create!(
   descount_amount: 10,
   final_value: 46,
   cpf: card.cpf,
-  status: 1,
-  card_number: card.number
+  status: :pending,
+  card_number: card.number,
+  payment_date: Date.today
 )
 Extract.create!(
   date: payment.created_at, operation_type: 'débito', value: payment.final_value,

--- a/spec/requests/APIs/get_company_card_types_api_spec.rb
+++ b/spec/requests/APIs/get_company_card_types_api_spec.rb
@@ -51,7 +51,7 @@ describe 'API do tipo de cartão' do
       expect(json_response.length).to eq 1
       expect(json_response[0]['name']).to eq 'Black'
       expect(json_response[0]['icon']).to eq 'icone'
-      expect(json_response[0]['id']).to eq 1
+      expect(json_response[0]['company_card_type_id']).to eq 1
       expect(json_response[0]['start_points']).to eq 210
       expect(json_response[0]['conversion_tax']).to eq 20.00
     end
@@ -79,7 +79,7 @@ describe 'API do tipo de cartão' do
       expect(json_response.length).to eq 1
       expect(json_response[0]['name']).to eq 'Black'
       expect(json_response[0]['icon']).to eq 'icone'
-      expect(json_response[0]['id']).to eq 1
+      expect(json_response[0]['company_card_type_id']).to eq 1
       expect(json_response[0]['start_points']).to eq 210
       expect(json_response[0]['conversion_tax']).to eq 20.00
     end
@@ -108,12 +108,12 @@ describe 'API do tipo de cartão' do
       expect(json_response.length).to eq 2
       expect(json_response[0]['name']).to eq 'Black'
       expect(json_response[0]['icon']).to eq 'icone'
-      expect(json_response[0]['id']).to eq 1
+      expect(json_response[0]['company_card_type_id']).to eq 1
       expect(json_response[0]['start_points']).to eq 210
       expect(json_response[0]['conversion_tax']).to eq 20.00
       expect(json_response[1]['name']).to eq 'Starter'
       expect(json_response[1]['icon']).to eq 'icone2'
-      expect(json_response[1]['id']).to eq 2
+      expect(json_response[1]['company_card_type_id']).to eq 2
       expect(json_response[1]['start_points']).to eq 150
       expect(json_response[1]['conversion_tax']).to eq 12.00
     end

--- a/spec/requests/APIs/show_card_api_spec.rb
+++ b/spec/requests/APIs/show_card_api_spec.rb
@@ -10,9 +10,15 @@ describe 'API de consulta de cartão' do
       expect(response.status).to eq 200
       expect(response.content_type).to include 'application/json'
       json_response = response.parsed_body
-      expect(json_response['cpf']).to eq '66268563670'
+      expect(json_response['id']).to eq card.id
+      expect(json_response['cpf']).to eq card.cpf
       expect(json_response['number']).to eq card.number
+      expect(json_response['points']).to eq card.points
+      expect(json_response['status']).to eq card.status
+      expect(json_response['name']).to eq card.company_card_type.card_type.name
+      expect(json_response['conversion_tax']).to eq card.company_card_type.conversion_tax.to_s
     end
+
     it 'e não encontra nenhum resultado' do
       get '/api/v1/cards/72477982036'
 


### PR DESCRIPTION
Correção de erros no enum de status e novo campo de data nas seeds de pagamento.

Adição da taxa de conversão do cartão no retorno do endpoint de cartão.

Renomeação de id para company_card_type_id na API de tipo de cartão.

close #35 