### PR TITLE
Envio de ícone pela rota show do cartão

### DIFF
--- a/app/controllers/api/v1/cards_controller.rb
+++ b/app/controllers/api/v1/cards_controller.rb
@@ -84,9 +84,14 @@ class Api::V1::CardsController < Api::V1::ApiController
     {
       id: card.id, cpf: card.cpf,
       number: card.number, points: card.points,
+      icon: url_for_icon(card),
       status: card.status, name: card.company_card_type.card_type.name,
       conversion_tax: card.company_card_type.conversion_tax,
       cashback: cashback.present? ? cashback.amount : 0
     }
+  end
+
+  def url_for_icon(card)
+    url_for(card.company_card_type.card_type.icon)
   end
 end

--- a/spec/requests/APIs/create_card_api_spec.rb
+++ b/spec/requests/APIs/create_card_api_spec.rb
@@ -49,6 +49,7 @@ describe 'API para emissão de cartão' do
       json_response = response.parsed_body
       expect(json_response['number']).to eq '12345678912345678912'
       expect(json_response['cpf']).to eq '12193448000158'
+      expect(json_response['icon']).to eq url_for(Card.last.company_card_type.card_type.icon)
       expect(json_response['status']).to eq 'active'
       expect(json_response['points']).to eq 100
       expect(json_response['name']).to eq 'Premium'

--- a/spec/requests/APIs/show_card_api_spec.rb
+++ b/spec/requests/APIs/show_card_api_spec.rb
@@ -30,6 +30,7 @@ describe 'API de consulta de cartão' do
       expect(json_response.is_a?(Array)).to eq(false)
       expect(json_response['id']).to eq card.id
       expect(json_response['cpf']).to eq card.cpf
+      expect(json_response['icon']).to eq url_for(card.company_card_type.card_type.icon)
       expect(json_response['number']).to eq card.number
       expect(json_response['points']).to eq card.points
       expect(json_response['status']).to eq card.status


### PR DESCRIPTION
close #70
Durante testes de aplicação verificamos a necessidade de se enviar o ícone no show do cartão para facilitar o uso com a aplicação de gestão de empresas. Ocorria um problema o qual após desabilitar a emissão de tipo de cartão ou a disponibilidade pra uma empresa a imagem do cartão não era mostrada mais.
