### PR TITLE
Mudança do cálculo da taxa de conversão

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ As seeds irão popular a aplicação com dados já prontos para facilitar a inte
 
     |Nome|Pontos|Status de Emissão|
     |----|------|-----------------|
-    |Gold|100|Ativo|
-    |Platinum|200|Ativo|
-    |Black|300|Inativo|
+    |Gold|1900|Ativo|
+    |Platinum|2500|Ativo|
+    |Black|3000|Inativo|
 3. Cartões Pré Cadastrados:
 
     |Id|CPF|Status|

--- a/app/helpers/reais_to_points_conversion_helper.rb
+++ b/app/helpers/reais_to_points_conversion_helper.rb
@@ -1,5 +1,5 @@
 module ReaisToPointsConversionHelper
   def reais_to_points(card, value)
-    (value + (value * (card.company_card_type.conversion_tax / 100))).round
+    (value * card.company_card_type.conversion_tax).round
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,7 +23,7 @@ ErrorMessage.create!(
   description: 'Administrador não aprovou a compra'
 )
 
-card_type = CardType.new(name: 'Gold', start_points: 100, emission: true)
+card_type = CardType.new(name: 'Gold', start_points: 1900, emission: true)
 card_type.icon.attach(
   io: Rails.root.join('spec/support/images/gold.svg').open,
   filename: 'gold.svg',
@@ -31,7 +31,7 @@ card_type.icon.attach(
 )
 card_type.save
 
-card_type2 = CardType.new(name: 'Platinum', start_points: 200, emission: true)
+card_type2 = CardType.new(name: 'Platinum', start_points: 2500, emission: true)
 card_type2.icon.attach(
   io: Rails.root.join('spec/support/images/premium.svg').open,
   filename: 'premium.svg',
@@ -39,7 +39,7 @@ card_type2.icon.attach(
 )
 card_type2.save
 
-other_card_type = CardType.new(name: 'Black', start_points: 300, emission: false)
+other_card_type = CardType.new(name: 'Black', start_points: 3000, emission: false)
 other_card_type.icon.attach(
   io: Rails.root.join('spec/support/images/black.svg').open,
   filename: 'black.svg',

--- a/spec/factories/card_types.rb
+++ b/spec/factories/card_types.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :card_type do
     name { 'Premium' }
-    start_points { 100 }
+    start_points { 1500 }
     emission { true }
 
     after :build do |card_type|

--- a/spec/factories/cards.rb
+++ b/spec/factories/cards.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :card do
     number { '31088319132162400813' }
     cpf { '66268563670' }
-    points { 100 }
+    points { 1500 }
     status { 0 }
     association :company_card_type
   end

--- a/spec/factories/cashback_rules.rb
+++ b/spec/factories/cashback_rules.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :cashback_rule do
-    minimum_amount_points { 300 }
+    minimum_amount_points { 500 }
     cashback_percentage { 9.99 }
     days_to_use { 10 }
   end

--- a/spec/requests/APIs/activate_card_api_spec.rb
+++ b/spec/requests/APIs/activate_card_api_spec.rb
@@ -44,7 +44,7 @@ describe 'API para ativação de cartão' do
       expect(json_response['number']).to eq '12345678912345678912'
       expect(json_response['cpf']).to eq '12193448000158'
       expect(json_response['status']).to eq 'active'
-      expect(json_response['points']).to eq 100
+      expect(json_response['points']).to eq 1500
       expect(json_response['name']).to eq 'Premium'
     end
   end

--- a/spec/requests/APIs/block_card_api_spec.rb
+++ b/spec/requests/APIs/block_card_api_spec.rb
@@ -44,7 +44,7 @@ describe 'API para bloqueio definitivo de cartão' do
       expect(json_response['number']).to eq '12345678912345678912'
       expect(json_response['cpf']).to eq '12193448000158'
       expect(json_response['status']).to eq 'blocked'
-      expect(json_response['points']).to eq 100
+      expect(json_response['points']).to eq 1500
       expect(json_response['name']).to eq 'Premium'
     end
   end

--- a/spec/requests/APIs/create_card_api_spec.rb
+++ b/spec/requests/APIs/create_card_api_spec.rb
@@ -50,7 +50,7 @@ describe 'API para emissão de cartão' do
       expect(json_response['number']).to eq '12345678912345678912'
       expect(json_response['cpf']).to eq '12193448000158'
       expect(json_response['status']).to eq 'active'
-      expect(json_response['points']).to eq 100
+      expect(json_response['points']).to eq 1500
       expect(json_response['name']).to eq 'Premium'
     end
   end

--- a/spec/requests/APIs/deactivate_card_api_spec.rb
+++ b/spec/requests/APIs/deactivate_card_api_spec.rb
@@ -44,7 +44,7 @@ describe 'API para desativação de cartão' do
       expect(json_response['number']).to eq '12345678912345678912'
       expect(json_response['cpf']).to eq '12193448000158'
       expect(json_response['status']).to eq 'inactive'
-      expect(json_response['points']).to eq 100
+      expect(json_response['points']).to eq 1500
       expect(json_response['name']).to eq 'Premium'
     end
   end

--- a/spec/requests/APIs/recharge_cards_api_spec.rb
+++ b/spec/requests/APIs/recharge_cards_api_spec.rb
@@ -17,7 +17,7 @@ describe 'API de recarga de cartões' do
       context 'e caso os dados sejam válidos:' do
         it 'atualiza os pontos, gera um deposito, gera um extrato e retorna mensagem de sucesso' do
           company = FactoryBot.create(:company_card_type, conversion_tax: 10)
-          card = FactoryBot.create(:card, cpf: '66268563670', points: 100, company_card_type: company)
+          card = FactoryBot.create(:card, cpf: '66268563670', company_card_type: company)
           request = { recharge: [{ cpf: card.cpf, value: 15 }] }
           patch '/api/v1/cards/recharge', params: request
           card.reload
@@ -29,11 +29,11 @@ describe 'API de recarga de cartões' do
           json_response = response.parsed_body
           expect(json_response[0]['cpf']).to eq '66268563670'
           expect(json_response[0]['message']).to eq 'Recarga efetuada com sucesso'
-          expect(card.points).to eq 117
+          expect(card.points).to eq 1650
           expect(card_deposit.card).to eq card
           expect(card_extract.card_number).to eq card.number
-          expect(card_deposit.amount).to eq 17
-          expect(card_extract.value).to eq 17
+          expect(card_deposit.amount).to eq 150
+          expect(card_extract.value).to eq 150
         end
 
         it 'retorne um erro caso a atualização não tenha sucesso' do
@@ -66,7 +66,7 @@ describe 'API de recarga de cartões' do
           json_response = response.parsed_body
           expect(json_response[0]['cpf']).to eq '66268563670'
           expect(json_response[0]['errors']).to eq 'Cartão não encontrado ou inativo'
-          expect(card.points).to eq 100
+          expect(card.points).to eq 1500
           expect(card_deposit).to be_falsy
           expect(card_extract).to be_falsy
         end
@@ -91,8 +91,8 @@ describe 'API de recarga de cartões' do
           expect(json_response[0]['message']).to eq 'Recarga efetuada com sucesso'
           expect(json_response[1]['cpf']).to eq '50226428087'
           expect(json_response[1]['message']).to eq 'Recarga efetuada com sucesso'
-          expect(first_card.points).to eq 117
-          expect(second_card.points).to eq 128
+          expect(first_card.points).to eq 1650
+          expect(second_card.points).to eq 1750
         end
 
         it 'gera um deposito e um extrato para cada' do
@@ -110,12 +110,12 @@ describe 'API de recarga de cartões' do
 
           expect(first_card_deposit.card).to eq first_card
           expect(first_card_extract.card_number).to eq first_card.number
-          expect(first_card_deposit.amount).to eq 17
-          expect(first_card_extract.value).to eq 17
+          expect(first_card_deposit.amount).to eq 150
+          expect(first_card_extract.value).to eq 150
           expect(second_card_deposit.card).to eq second_card
           expect(second_card_extract.card_number).to eq second_card.number
-          expect(second_card_deposit.amount).to eq 28
-          expect(second_card_extract.value).to eq 28
+          expect(second_card_deposit.amount).to eq 250
+          expect(second_card_extract.value).to eq 250
         end
       end
 
@@ -136,8 +136,8 @@ describe 'API de recarga de cartões' do
           expect(json_response[0]['message']).to eq 'Recarga efetuada com sucesso'
           expect(json_response[1]['cpf']).to eq '50226428087'
           expect(json_response[1]['errors']).to eq 'Cartão não encontrado ou inativo'
-          expect(first_card.points).to eq 117
-          expect(second_card.points).to eq 100
+          expect(first_card.points).to eq 1650
+          expect(second_card.points).to eq 1500
         end
 
         it 'gera um deposito e um extrato para o cartão que foi recarregado' do

--- a/spec/system/admin_register_cashback_rule_spec.rb
+++ b/spec/system/admin_register_cashback_rule_spec.rb
@@ -29,7 +29,7 @@ describe 'Administrador tenta registar uma nova regra de cashback' do
     within '#cashback' do
       click_on 'Nova regra de cashback'
     end
-    fill_in 'Valor mínimo', with: 300
+    fill_in 'Valor mínimo', with: 500
     fill_in 'Porcentagem de retorno', with: 9.99
     fill_in 'Quantidade de dias', with: 10
     click_on 'Criar regra'

--- a/spec/system/payment/admin_approves_payment_spec.rb
+++ b/spec/system/payment/admin_approves_payment_spec.rb
@@ -27,7 +27,7 @@ describe 'Administrador entra na tela de pagamentos' do
       it 'usando cashback com sucesso' do
         admin = FactoryBot.create(:admin)
         cashback_rule = FactoryBot.create(:cashback_rule, days_to_use: 10, cashback_percentage: 3,
-                                                          minimum_amount_points: 50)
+                                                          minimum_amount_points: 500)
         company_card_type = FactoryBot.create(:company_card_type, cashback_rule:, conversion_tax: 20.5)
         card = FactoryBot.create(:card, company_card_type:, points: 1500)
 
@@ -58,7 +58,7 @@ describe 'Administrador entra na tela de pagamentos' do
       it 'sem usar cashback pois o cashback que existia já expirou' do
         admin = FactoryBot.create(:admin)
         cashback_rule = FactoryBot.create(:cashback_rule, days_to_use: 10, cashback_percentage: 3,
-                                                          minimum_amount_points: 50)
+                                                          minimum_amount_points: 500)
         company_card_type = FactoryBot.create(:company_card_type, cashback_rule:, conversion_tax: 20.5)
         card = FactoryBot.create(:card, company_card_type:, points: 1500)
 
@@ -88,7 +88,7 @@ describe 'Administrador entra na tela de pagamentos' do
       it 'e tenta aprovar outro, porém falha pois não há saldo suficiente no cartão' do
         admin = FactoryBot.create(:admin)
         cashback_rule = FactoryBot.create(:cashback_rule, days_to_use: 10, cashback_percentage: 3,
-                                                          minimum_amount_points: 50)
+                                                          minimum_amount_points: 500)
         company_card_type = FactoryBot.create(:company_card_type, cashback_rule:, conversion_tax: 20.5)
         card = FactoryBot.create(:card, company_card_type:, points: 1500)
 
@@ -118,7 +118,7 @@ describe 'Administrador entra na tela de pagamentos' do
       it 'e tenta aprovar, porém houve erro durante a transação' do
         admin = FactoryBot.create(:admin)
         cashback_rule = FactoryBot.create(:cashback_rule, days_to_use: 10, cashback_percentage: 3,
-                                                          minimum_amount_points: 50)
+                                                          minimum_amount_points: 500)
         company_card_type = FactoryBot.create(:company_card_type, cashback_rule:, conversion_tax: 20.5)
         card = FactoryBot.create(:card, company_card_type:, points: 1500)
         payment = FactoryBot.create(:payment, cpf: card.cpf, card_number: card.number, final_value: 50)
@@ -139,7 +139,7 @@ describe 'Administrador entra na tela de pagamentos' do
       it 'e gera um cashback corretamente' do
         admin = FactoryBot.create(:admin)
         cashback_rule = FactoryBot.create(:cashback_rule, days_to_use: 10, cashback_percentage: 3,
-                                                          minimum_amount_points: 50)
+                                                          minimum_amount_points: 500)
         company_card_type = FactoryBot.create(:company_card_type, cashback_rule:, conversion_tax: 20.5)
         card = FactoryBot.create(:card, company_card_type:, points: 1500)
         payment = FactoryBot.create(:payment, cpf: card.cpf, card_number: card.number, final_value: 50)

--- a/spec/system/payment/admin_approves_payment_spec.rb
+++ b/spec/system/payment/admin_approves_payment_spec.rb
@@ -5,7 +5,7 @@ describe 'Administrador entra na tela de pagamentos' do
     describe 'um pagamento pré aprovado' do
       it 'sem usar cashback pois não existe nenhum' do
         admin = FactoryBot.create(:admin)
-        card = FactoryBot.create(:card)
+        card = FactoryBot.create(:card, points: 1500)
         payment = FactoryBot.create(:payment, cpf: card.cpf, card_number: card.number, final_value: 5)
 
         login_as admin
@@ -29,7 +29,7 @@ describe 'Administrador entra na tela de pagamentos' do
         cashback_rule = FactoryBot.create(:cashback_rule, days_to_use: 10, cashback_percentage: 3,
                                                           minimum_amount_points: 50)
         company_card_type = FactoryBot.create(:company_card_type, cashback_rule:, conversion_tax: 20.5)
-        card = FactoryBot.create(:card, company_card_type:, points: 100)
+        card = FactoryBot.create(:card, company_card_type:, points: 1500)
 
         other_payment = FactoryBot.create(:payment, order_number: 465_452, cpf: card.cpf, card_number: card.number,
                                                     final_value: 100)
@@ -52,7 +52,7 @@ describe 'Administrador entra na tela de pagamentos' do
         end
 
         expect(Cashback.first.used).to eq(true)
-        expect(Card.first.points).to eq(45)
+        expect(Card.first.points).to eq(480)
       end
 
       it 'sem usar cashback pois o cashback que existia já expirou' do
@@ -60,7 +60,7 @@ describe 'Administrador entra na tela de pagamentos' do
         cashback_rule = FactoryBot.create(:cashback_rule, days_to_use: 10, cashback_percentage: 3,
                                                           minimum_amount_points: 50)
         company_card_type = FactoryBot.create(:company_card_type, cashback_rule:, conversion_tax: 20.5)
-        card = FactoryBot.create(:card, company_card_type:, points: 100)
+        card = FactoryBot.create(:card, company_card_type:, points: 1500)
 
         other_payment = FactoryBot.create(:payment, order_number: 465_452, cpf: card.cpf, card_number: card.number,
                                                     final_value: 100)
@@ -82,7 +82,7 @@ describe 'Administrador entra na tela de pagamentos' do
           expect(page).not_to have_content "Pedido #{payment.order_number}"
         end
         expect(Cashback.first.used).to eq(false)
-        expect(Card.first.points).to eq(40)
+        expect(Card.first.points).to eq(475)
       end
 
       it 'e tenta aprovar outro, porém falha pois não há saldo suficiente no cartão' do
@@ -90,7 +90,7 @@ describe 'Administrador entra na tela de pagamentos' do
         cashback_rule = FactoryBot.create(:cashback_rule, days_to_use: 10, cashback_percentage: 3,
                                                           minimum_amount_points: 50)
         company_card_type = FactoryBot.create(:company_card_type, cashback_rule:, conversion_tax: 20.5)
-        card = FactoryBot.create(:card, company_card_type:, points: 100)
+        card = FactoryBot.create(:card, company_card_type:, points: 1500)
 
         other_payment = FactoryBot.create(:payment, order_number: 465_452, cpf: card.cpf, card_number: card.number,
                                                     final_value: 50)
@@ -120,7 +120,7 @@ describe 'Administrador entra na tela de pagamentos' do
         cashback_rule = FactoryBot.create(:cashback_rule, days_to_use: 10, cashback_percentage: 3,
                                                           minimum_amount_points: 50)
         company_card_type = FactoryBot.create(:company_card_type, cashback_rule:, conversion_tax: 20.5)
-        card = FactoryBot.create(:card, company_card_type:, points: 100)
+        card = FactoryBot.create(:card, company_card_type:, points: 1500)
         payment = FactoryBot.create(:payment, cpf: card.cpf, card_number: card.number, final_value: 50)
         allow(Extract).to receive(:create).and_raise(ActiveRecord::RecordInvalid)
 
@@ -141,7 +141,7 @@ describe 'Administrador entra na tela de pagamentos' do
         cashback_rule = FactoryBot.create(:cashback_rule, days_to_use: 10, cashback_percentage: 3,
                                                           minimum_amount_points: 50)
         company_card_type = FactoryBot.create(:company_card_type, cashback_rule:, conversion_tax: 20.5)
-        card = FactoryBot.create(:card, company_card_type:)
+        card = FactoryBot.create(:card, company_card_type:, points: 1500)
         payment = FactoryBot.create(:payment, cpf: card.cpf, card_number: card.number, final_value: 50)
 
         login_as admin
@@ -159,13 +159,13 @@ describe 'Administrador entra na tela de pagamentos' do
           expect(page).not_to have_content "Pedido #{payment.order_number}"
         end
 
-        expect(Cashback.all.first.amount).to eq(2)
+        expect(Cashback.all.first.amount).to eq(31)
       end
 
       it 'e não gera um cashback pois o valor em pontos da compra não satisfaz o mínimo' do
         admin = FactoryBot.create(:admin)
         cashback_rule = FactoryBot.create(:cashback_rule, days_to_use: 10, cashback_percentage: 3,
-                                                          minimum_amount_points: 50)
+                                                          minimum_amount_points: 500)
         company_card_type = FactoryBot.create(:company_card_type, cashback_rule:, conversion_tax: 20.5)
         card = FactoryBot.create(:card, company_card_type:)
         payment = FactoryBot.create(:payment, cpf: card.cpf, card_number: card.number, final_value: 10)
@@ -194,7 +194,7 @@ describe 'Administrador entra na tela de pagamentos' do
         FactoryBot.create(:error_message, code: '003', description: 'Cartão não pertence ao CPF informado')
         FactoryBot.create(:error_message, code: '004', description: 'Valor da compra é maior que o saldo do cartão')
         admin = FactoryBot.create(:admin)
-        card = FactoryBot.create(:card, cpf: '22253043001')
+        card = FactoryBot.create(:card, cpf: '22253043001', points: 1500)
         first_pay = FactoryBot.create(:payment, cpf: '22253043001', card_number: card.number, order_number: '1234567')
         second_pay = FactoryBot.create(:payment, cpf: '19261109004', card_number: card.number, order_number: '7845123')
 
@@ -222,7 +222,7 @@ describe 'Administrador entra na tela de pagamentos' do
 
       it 'e gera um extrato de pagamento' do
         admin = FactoryBot.create(:admin)
-        card = FactoryBot.create(:card)
+        card = FactoryBot.create(:card, points: 1500)
         payment = FactoryBot.create(:payment, cpf: card.cpf, card_number: card.number, final_value: 5)
 
         login_as admin
@@ -237,7 +237,7 @@ describe 'Administrador entra na tela de pagamentos' do
         extract = Extract.first
         expect(Extract.all.length).to eq 1
         expect(extract.date).to eq payment.payment_date
-        expect(extract.value).to eq 5
+        expect(extract.value).to eq 50
         expect(extract.card_number).to eq card.number
         expect(extract.description).to eq "Pedido #{payment.order_number}"
         expect(extract.operation_type).to eq 'débito'
@@ -246,10 +246,10 @@ describe 'Administrador entra na tela de pagamentos' do
       it 'e gera um extrato de cashback' do
         admin = FactoryBot.create(:admin)
         cashback_rule = FactoryBot.create(:cashback_rule, cashback_percentage: 3, days_to_use: 10,
-                                                          minimum_amount_points: 50)
+                                                          minimum_amount_points: 500)
         company_card_type = FactoryBot.create(:company_card_type, cashback_rule:, conversion_tax: 20)
         card = FactoryBot.create(:card, company_card_type:)
-        card.update!(points: 200)
+        card.update!(points: 2000)
         payment = FactoryBot.create(:payment, cpf: card.cpf, card_number: card.number, final_value: 100)
 
         login_as admin
@@ -266,7 +266,7 @@ describe 'Administrador entra na tela de pagamentos' do
         venc = card.company_card_type.cashback_rule.days_to_use
         expect(Extract.all.length).to eq 2
         expect(extract.date).to eq cashback.created_at
-        expect(extract.value).to eq 4
+        expect(extract.value).to eq 60
         expect(extract.card_number).to eq card.number
         expect(extract.description).to eq "Cashback #{payment.order_number} Válido por #{venc} dia(s)"
         expect(extract.operation_type).to eq 'crédito'
@@ -277,7 +277,7 @@ describe 'Administrador entra na tela de pagamentos' do
   context 'e reprova' do
     it 'um pagamento pre aprovado com sucesso' do
       admin = FactoryBot.create(:admin)
-      card = FactoryBot.create(:card)
+      card = FactoryBot.create(:card, points: 1500)
       payment = FactoryBot.create(:payment, cpf: card.cpf, card_number: card.number, final_value: 5)
 
       login_as admin
@@ -302,7 +302,7 @@ describe 'Administrador entra na tela de pagamentos' do
       FactoryBot.create(:error_message, code: '003', description: 'Cartão não pertence ao CPF informado')
       FactoryBot.create(:error_message, code: '004', description: 'Valor da compra é maior que o saldo do cartão')
       admin = FactoryBot.create(:admin)
-      card = FactoryBot.create(:card, cpf: '22253043001')
+      card = FactoryBot.create(:card, cpf: '22253043001', points: 1500)
       payment = FactoryBot.create(:payment, cpf: '19261109004', card_number: card.number)
 
       login_as admin
@@ -328,7 +328,7 @@ describe 'Administrador entra na tela de pagamentos' do
       FactoryBot.create(:error_message, code: '003', description: 'Cartão não pertence ao CPF informado')
       FactoryBot.create(:error_message, code: '004', description: 'Valor da compra é maior que o saldo do cartão')
       admin = FactoryBot.create(:admin)
-      card = FactoryBot.create(:card, cpf: '22253043001')
+      card = FactoryBot.create(:card, cpf: '22253043001', points: 1500)
       first_pay = FactoryBot.create(:payment, cpf: '22253043001', card_number: card.number, order_number: '1234567')
       second_pay = FactoryBot.create(:payment, cpf: '19261109004', card_number: card.number, order_number: '7845123')
 

--- a/spec/system/payment/admin_visit_finished_payment_page_spec.rb
+++ b/spec/system/payment/admin_visit_finished_payment_page_spec.rb
@@ -53,6 +53,7 @@ describe 'Administrador entra na tela de pagamentos finalizados' do
     FactoryBot.create(:error_message, code: '005', description: 'Administrador não aprovou a compra')
     admin = FactoryBot.create(:admin)
     card = FactoryBot.create(:card, cpf: '22253043001')
+    card.update!(points: 1500)
     payment = FactoryBot.create(:payment, cpf: '19261109004', card_number: card.number)
     payment.rejected!
     ErrorsAssociation.create(payment_id: payment.id, error_message_id: 5)
@@ -82,6 +83,7 @@ describe 'Administrador entra na tela de pagamentos finalizados' do
     FactoryBot.create(:error_message, code: '005', description: 'Administrador não aprovou a compra')
     admin = FactoryBot.create(:admin)
     card = FactoryBot.create(:card, cpf: '22253043001')
+    card.update!(points: 1500)
     payment = FactoryBot.create(:payment, cpf: card.cpf, card_number: card.number)
     payment.rejected!
     ErrorsAssociation.create(payment_id: payment.id, error_message_id: 5)


### PR DESCRIPTION
close #67 
O cálculo das taxas de conversão estavam divergentes entre o nosso time e o time da loja, portanto decidimos por alterar aqui, pois seria mais simples e facilitaria para todos. Além disso foi alterado nas factories os pontos iniciais e minimum amount points para ficar mais condizente com a quantidade de pontos. Testes também foram alterados.